### PR TITLE
ci: tag before committing

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git tag -f ${{ github.ref_name }}
           git commit -m "chore(core): bump version to ${{ github.ref_name }}"
+          git tag -f ${{ github.ref_name }}
 
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0


### PR DESCRIPTION
The tag currently is at the wrong place, before pushing the new version.